### PR TITLE
added patch to deploy to dev

### DIFF
--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitFailInvalidWorkingDirectory.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessAdditionalArgs.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessEmptyWorkingDir.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/Tests/InitTests/GCP/GCPInitSuccessNoAdditionalArgs.ts
@@ -38,7 +38,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
     }
 }
 
-tr.registerMock('uuid/v4', () => '123');
+tr.registerMock('uuid/v5', () => '123');
 tr.setAnswers(a);
 
 tr.run();

--- a/Tasks/TerraformTask/TerraformTaskV4/src/gcp-terraform-command-handler.ts
+++ b/Tasks/TerraformTask/TerraformTaskV4/src/gcp-terraform-command-handler.ts
@@ -3,7 +3,7 @@ import {ToolRunner} from 'azure-pipelines-task-lib/toolrunner';
 import {TerraformAuthorizationCommandInitializer} from './terraform-commands';
 import {BaseTerraformCommandHandler} from './base-terraform-command-handler';
 import path = require('path');
-import * as uuidV4 from 'uuid/v4';
+import * as uuidV5 from 'uuid/v5';
 
 export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
     constructor() {
@@ -13,7 +13,7 @@ export class TerraformCommandHandlerGCP extends BaseTerraformCommandHandler {
 
     private getJsonKeyFilePath(serviceName: string) {
         // Get credentials for json file
-        const jsonKeyFilePath = path.resolve(`credentials-${uuidV4()}.json`);
+        const jsonKeyFilePath = path.resolve(`credentials-${uuidV5(serviceName, uuidV5.URL)}.json`);
 
         let clientEmail = tasks.getEndpointAuthorizationParameter(serviceName, "Issuer", false);
         let tokenUri = tasks.getEndpointAuthorizationParameter(serviceName, "Audience", false);


### PR DESCRIPTION
### Description

The changes in this pull request consist of updating the uuid package from version 4 to version 5, as well as modifying the implementation in the GCP Terraform command handler related to generating a JSON key file path.

- Updated the uuid package usage from version 4 to version 5 in the GCP Terraform command handler implementation.
- Modified the generation of the JSON key file path in the GCP Terraform command handler to use uuid v5 with service name and URL.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the UUID version from v4 to v5 in GCP Terraform task tests and command handler.

### Why are these changes being made?

The change ensures that UUIDs are generated using a namespace-based approach (UUID v5) rather than a random-based approach (UUID v4), which is more suitable for generating consistent and deterministic identifiers, especially when using service names as input. This update improves the reliability and predictability of the generated file paths and mock identifiers in the tests and command handler.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->